### PR TITLE
Allow usage of evenement v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php"                 : ">=5.3.3",
-        "evenement/evenement" : "~1.0",
+        "evenement/evenement" : "^2.0|^1.0",
         "monolog/monolog"     : "~1.3",
         "psr/log"             : "~1.0",
         "symfony/process"     : "~2.0"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | an enhancement
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes (travis failes on php 5.3 with missing openssl extension)
| Fixed tickets | none
| License | MIT

#### Description

The `evenement` lib v2.0 major BC break was the removement of `EventEmitter2` class, which is not used in the `BinaryDriver`. Thus it is possible to require both versions, v1.0 and v2.0 via composer.

Would be nice to get directly a new bugfix release after this is merged :grin:  

#### Purpose

Example: Users of lib A which requires `react/socket` which requires `evenement` in v2.0 but also require `php-ffmpeg/php-ffmpeg` which requires your `BinaryDriver` have a dependency conflict and have to manually add `"evenement/evenement": "2.0.0 as 1.0.0"` to their projects composer. Because of the v1.0 to v2.0 compatibility this works, so you can simply support both versions.