### PR TITLE
Log process error output

### DIFF
--- a/src/Alchemy/BinaryDriver/ProcessRunner.php
+++ b/src/Alchemy/BinaryDriver/ProcessRunner.php
@@ -72,7 +72,7 @@ class ProcessRunner implements ProcessRunnerInterface
             $this->doExecutionFailure($process->getCommandLine());
         } elseif (!$process->isSuccessful()) {
             $this->logger->error(sprintf(
-                '%s failed to execute command %s', $this->name, $process->getCommandLine()
+                '%s failed to execute command %s: %s', $this->name, $process->getCommandLine(), $process->getErrorOutput()
             ));
 
             return;


### PR DESCRIPTION
While debugging errors from `php-ffmpeg/php-ffmpeg`, I realized this library's `ProcessRunner` doesn't log the actual error output when a process fails. This PR adds that extra bit of information to the log.