### PR TITLE
Saving process object for later use.

### DIFF
--- a/src/Alchemy/BinaryDriver/AbstractBinary.php
+++ b/src/Alchemy/BinaryDriver/AbstractBinary.php
@@ -36,6 +36,9 @@ abstract class AbstractBinary extends EventEmitter implements BinaryInterface
     /** @var Listeners */
     private $listenersManager;
 
+    /** @var Process */
+    private $lastProcess;
+
     public function __construct(ProcessBuilderFactoryInterface $factory, LoggerInterface $logger, ConfigurationInterface $configuration)
     {
         $this->factory = $factory;
@@ -134,7 +137,17 @@ abstract class AbstractBinary extends EventEmitter implements BinaryInterface
             $command = array($command);
         }
 
-        return $this->run($this->factory->create($command), $bypassErrors, $listeners);
+        // what if we still need to access the process object?
+        $this->lastProcess = $this->factory->create($command);
+        return $this->run($this->lastProcess, $bypassErrors, $listeners);
+    }
+
+    /**
+     * @return Process Last ran process
+     */
+    public function getLastProcess()
+    {
+        return $this->lastProcess;
     }
 
     /**


### PR DESCRIPTION
For my particular case I need to redirect streams (like stderr to stdout). But anyway, I don't see why we should destroy this object and loose the ability to later get more info about the created process.