### PR TITLE
Add command error output to stderr

### DIFF
--- a/src/Alchemy/BinaryDriver/Exception/ExecutionFailureException.php
+++ b/src/Alchemy/BinaryDriver/Exception/ExecutionFailureException.php
@@ -13,4 +13,25 @@ namespace Alchemy\BinaryDriver\Exception;
 
 class ExecutionFailureException extends \RuntimeException implements ExceptionInterface
 {
+    /** @var string */
+    protected $command;
+
+    /** @var string */
+    protected $errorOutput;
+
+    public function __construct($binaryName, $command, $errorOutput = null, $code = 0, $previous = null)
+    {
+        $message = sprintf("%s failed to execute command %s:\n\nError Output:\n\n %s", $binaryName, $command, $errorOutput);
+        parent::__construct($message, $code, $previous);
+        $this->command = $command;
+        $this->errorOutput = $errorOutput;
+    }
+
+    public function getCommand(){
+        return $this->command;
+    }
+
+    public function getErrorOutput(){
+        return $this->errorOutput;
+    }
 }

--- a/src/Alchemy/BinaryDriver/ProcessRunner.php
+++ b/src/Alchemy/BinaryDriver/ProcessRunner.php
@@ -64,21 +64,18 @@ class ProcessRunner implements ProcessRunnerInterface
             $process->run($this->buildCallback($listeners));
         } catch (RuntimeException $e) {
             if (!$bypassErrors) {
-                $this->doExecutionFailure($process->getCommandLine(), $e);
+                $this->doExecutionFailure($process->getCommandLine(), $process->getErrorOutput(), $e);
             }
         }
 
-        if (!$bypassErrors && !$process->isSuccessful()) {
-            $this->doExecutionFailure($process->getCommandLine());
-        } elseif (!$process->isSuccessful()) {
-            $this->logger->error(sprintf(
-                '%s failed to execute command %s: %s', $this->name, $process->getCommandLine(), $process->getErrorOutput()
-            ));
 
+        if (!$bypassErrors && !$process->isSuccessful()) {
+            $this->doExecutionFailure($process->getCommandLine(), $process->getErrorOutput());
+        } elseif (!$process->isSuccessful()) {
+            $this->logger->error($this->createErrorMessage($process->getCommandLine(), $process->getErrorOutput()));
             return;
         } else {
             $this->logger->info(sprintf('%s executed command successfully', $this->name));
-
             return $process->getOutput();
         }
     }
@@ -92,13 +89,14 @@ class ProcessRunner implements ProcessRunnerInterface
         };
     }
 
-    private function doExecutionFailure($command, \Exception $e = null)
+    private function doExecutionFailure($command, $errorOutput, \Exception $e = null)
     {
-        $this->logger->error(sprintf(
-            '%s failed to execute command %s', $this->name, $command
-        ));
-        throw new ExecutionFailureException(sprintf(
-            '%s failed to execute command %s', $this->name, $command
-        ), $e ? $e->getCode() : null, $e ?: null);
+        $this->logger->error($this->createErrorMessage($command, $errorOutput));
+        throw new ExecutionFailureException($this->createErrorMessage($command, $errorOutput),
+            $e ? $e->getCode() : null, $e ?: null);
+    }
+
+    private function createErrorMessage($command, $errorOutput){
+        return sprintf('%s failed to execute command %s: %s', $this->name, $command, $errorOutput);
     }
 }

--- a/src/Alchemy/BinaryDriver/ProcessRunner.php
+++ b/src/Alchemy/BinaryDriver/ProcessRunner.php
@@ -93,7 +93,7 @@ class ProcessRunner implements ProcessRunnerInterface
     {
         $this->logger->error($this->createErrorMessage($command, $errorOutput));
         throw new ExecutionFailureException($this->name, $command, $errorOutput,
-            $e ? $e->getCode() : null, $e ?: null);
+            $e ? $e->getCode() : 0, $e ?: null);
     }
 
     private function createErrorMessage($command, $errorOutput){

--- a/src/Alchemy/BinaryDriver/ProcessRunner.php
+++ b/src/Alchemy/BinaryDriver/ProcessRunner.php
@@ -92,7 +92,7 @@ class ProcessRunner implements ProcessRunnerInterface
     private function doExecutionFailure($command, $errorOutput, \Exception $e = null)
     {
         $this->logger->error($this->createErrorMessage($command, $errorOutput));
-        throw new ExecutionFailureException($this->createErrorMessage($command, $errorOutput),
+        throw new ExecutionFailureException($this->name, $command, $errorOutput,
             $e ? $e->getCode() : null, $e ?: null);
     }
 

--- a/tests/Alchemy/Tests/BinaryDriver/Exceptions/ExecutionFailureExceptionTest.php
+++ b/tests/Alchemy/Tests/BinaryDriver/Exceptions/ExecutionFailureExceptionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Alchemy\Tests\BinaryDriver\Exceptions;
+
+use Alchemy\BinaryDriver\BinaryDriverTestCase;
+use Alchemy\BinaryDriver\Exception\ExecutionFailureException;
+use Alchemy\BinaryDriver\ProcessRunner;
+
+class ExecutionFailureExceptionTest extends BinaryDriverTestCase
+{
+    public function getProcessRunner($logger)
+    {
+        return new ProcessRunner($logger, 'test-runner');
+    }
+
+    public function testGetExceptionInfo(){
+
+        $logger = $this->createLoggerMock();
+        $runner = $this->getProcessRunner($logger);
+
+        $process = $this->createProcessMock(1, false, '--helloworld--', null, "Error Output", true);
+        try{
+            $runner->run($process, new \SplObjectStorage(), false);
+            $this->fail('An exception should have been raised');
+        }
+        catch (ExecutionFailureException $e){
+            $this->assertEquals("--helloworld--", $e->getCommand());
+            $this->assertEquals("Error Output", $e->getErrorOutput());
+        }
+
+    }
+
+}


### PR DESCRIPTION
This commit appends the error message from the command executed to the ProcessRunner error output. Since the creation and formatting of the error message was duplicated across the code, a private method was created solely for this purpose. This method received the error output as the second parameter, and appends it to the final message.

Closes #29 