### PR TITLE
Support Symfony5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "evenement/evenement" : "^2.0|^1.0",
         "monolog/monolog"     : "^1.3",
         "psr/log"             : "^1.0",
-        "symfony/process"     : "^2.3|^3.0|^4.0"
+        "symfony/process"     : "^2.3|^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit"     : "^4.0|^5.0"


### PR DESCRIPTION
There may be a problem since the Symfony5 process now separates the command from the arguments, the first step is being able to install with Symfony5.

In particular, I don't know if this line in ProcessRunner.php is still valid:

    $process->run($this->buildCallback($listeners));