### PR TITLE
Remove PHP5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ language: php
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
 
 matrix:
   include:
-    - php: 5.5
-      env: COMPOSER_OPTIONS="--prefer-lowest --prefer-stable"
     - php: 7.0
       env: COMPOSER_REQUIRE="symfony/process:^2.0"
     - php: 7.0


### PR DESCRIPTION
PHP5 is dead, and has been for almost a year.  IMO, it would be better to support 7.4 and Symfony 5 than the older versions of PHP.